### PR TITLE
feat: Implement blog categories and tags

### DIFF
--- a/src/content/blog/combining-astro-tailwind.md
+++ b/src/content/blog/combining-astro-tailwind.md
@@ -1,0 +1,13 @@
+---
+title: "Combining Astro and Tailwind CSS"
+slug: "astro-tailwind-combo"
+date: "2024-03-15"
+description: "How to effectively use Astro and Tailwind CSS together for your projects."
+category: "Astro Basics" # Same category as first post for testing
+tags: ["astro", "tailwindcss", "integration"]
+image: "/placeholder-images/astro-tailwind.jpg"
+---
+
+Astro and Tailwind CSS are a powerful combination.
+Astro handles the static site generation, and Tailwind provides the styling utilities.
+This setup allows for fast, performant, and beautifully designed websites.

--- a/src/content/blog/first-post.md
+++ b/src/content/blog/first-post.md
@@ -1,0 +1,13 @@
+---
+title: "My First Astro Blog Post"
+slug: "first-post"
+date: "2024-03-10"
+description: "Exploring the basics of Astro and how to set up a blog."
+category: "Astro Basics"
+tags: ["astro", "beginner", "tutorial"]
+image: "/placeholder-images/first-post.jpg" # You can use a placeholder path
+---
+
+This is the content of my first blog post. I'm excited to explore Astro!
+It's a modern static site generator that's gaining a lot of popularity.
+Stay tuned for more updates.

--- a/src/content/blog/tailwind-tips.md
+++ b/src/content/blog/tailwind-tips.md
@@ -1,0 +1,15 @@
+---
+title: "Tailwind CSS Tips for Beginners"
+slug: "tailwind-tips"
+date: "2024-03-12"
+description: "Some useful tips and tricks for getting started with Tailwind CSS."
+category: "CSS Frameworks"
+tags: ["tailwindcss", "css", "frontend", "tips"]
+image: "/placeholder-images/tailwind-tips.jpg"
+---
+
+Tailwind CSS is a utility-first CSS framework that helps build custom designs rapidly.
+Here are a few tips:
+- Use `@apply` for custom components.
+- Configure your `tailwind.config.js` effectively.
+- Explore plugins like Typography.

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -7,7 +7,9 @@ const blog = defineCollection({
     title: z.string(),
     slug: z.string(),
     date: z.coerce.date(),
-    image: z.string().optional()
+    image: z.string().optional(),
+    category: z.string().optional(),
+    tags: z.array(z.string()).optional()
   })
 });
 

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -17,6 +17,26 @@ const { frontmatter, default: Content } = post;
 ---
 <article class="container mx-auto py-8">
   <h1 class="text-4xl font-playfair mb-4">{frontmatter.title}</h1>
-  <p class="text-sm text-gray-500 mb-8">{new Date(frontmatter.date).toLocaleDateString()}</p>
-  <Content />
+  <p class="text-sm text-gray-500 mb-2">{new Date(frontmatter.date).toLocaleDateString()}</p>
+
+  {/* Display Category */}
+  {frontmatter.category && (
+    <p class="text-md text-gray-700 mb-2">
+      <strong>Category:</strong> <a href={`/blog?category=${encodeURIComponent(frontmatter.category)}`} class="text-[color:var(--primary)] hover:underline">{frontmatter.category}</a>
+    </p>
+  )}
+
+  {/* Display Tags */}
+  {frontmatter.tags && frontmatter.tags.length > 0 && (
+    <div class="mb-6"> {/* Adjusted margin bottom for spacing before Content */}
+      <strong>Tags:</strong>
+      {frontmatter.tags.map(tag => (
+        <a href={`/blog?tag=${encodeURIComponent(tag)}`} class="inline-block bg-gray-200 text-gray-700 text-xs px-2 py-0.5 rounded-full mr-2 mb-1 hover:bg-gray-300">{tag}</a>
+      ))}
+    </div>
+  )}
+
+  <div class="prose max-w-none mt-8"> {/* Added a wrapper for Content with some top margin */}
+    <Content />
+  </div>
 </article>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -4,22 +4,93 @@ title: "Blog"
 ---
 <script lang="ts">
   const modules = import.meta.glob('../../content/blog/*.md', { eager: true });
-  const posts = Object.entries(modules)
+  const allPosts = Object.entries(modules)
     .map(([path, post]: [string, any]) => {
       const slug = path.split('/').pop().replace('.md', '');
-      return { slug, ...(post.frontmatter as any) };
+      // Explicitly include category and tags, and other necessary fields
+      return {
+        slug,
+        title: post.frontmatter.title,
+        date: post.frontmatter.date,
+        description: post.frontmatter.description,
+        image: post.frontmatter.image,
+        category: post.frontmatter.category,
+        tags: post.frontmatter.tags,
+      };
     })
     .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+
+  const uniqueCategories = [...new Set(allPosts.map(post => post.category).filter(Boolean as <T>(x: T | undefined): x is T => Boolean(x)))];
+  const uniqueTags = [...new Set(allPosts.flatMap(post => post.tags || []).filter(Boolean as <T>(x: T | undefined): x is T => Boolean(x)))];
+
+  const activeCategory = Astro.url.searchParams.get('category');
+  const activeTag = Astro.url.searchParams.get('tag');
+
+  let filteredPosts = allPosts;
+
+  if (activeCategory) {
+    filteredPosts = allPosts.filter(post => post.category === activeCategory);
+  } else if (activeTag) {
+    filteredPosts = allPosts.filter(post => post.tags && post.tags.includes(activeTag));
+  }
 </script>
 <section class="container mx-auto py-8">
   <h1 class="text-4xl font-playfair mb-4">Blog</h1>
-  <ul class="space-y-6">
-    {posts.map(post => (
-      <li>
-        <a href={`/blog/${post.slug}`} class="text-2xl font-playfair text-[color:var(--primary)] hover:underline">{post.title}</a>
-        <p class="text-sm text-gray-500">{new Date(post.date).toLocaleDateString()}</p>
-        <p class="mt-1">{post.description}</p>
+
+  <!-- Category Filters -->
+  {uniqueCategories.length > 0 && (
+    <div class="mb-4">
+      <h3 class="text-xl font-semibold">Categories</h3>
+      <ul class="flex space-x-2 mt-2">
+        <li><a href="/blog" class="text-[color:var(--primary)] hover:underline">All</a></li>
+        {uniqueCategories.map(category => (
+          <li><a href={`/blog?category=${encodeURIComponent(category)}`} class="text-[color:var(--primary)] hover:underline">{category}</a></li>
+        ))}
+      </ul>
+    </div>
+  )}
+
+  <!-- Tag Filters -->
+  {uniqueTags.length > 0 && (
+    <div class="mb-8">
+      <h3 class="text-xl font-semibold">Tags</h3>
+      <ul class="flex flex-wrap gap-2 mt-2">
+        <li><a href="/blog" class="px-3 py-1 bg-gray-200 text-gray-700 rounded-full text-sm hover:bg-gray-300">All</a></li>
+        {uniqueTags.map(tag => (
+          <li><a href={`/blog?tag=${encodeURIComponent(tag)}`} class="px-3 py-1 bg-gray-200 text-gray-700 rounded-full text-sm hover:bg-gray-300">{tag}</a></li>
+        ))}
+      </ul>
+    </div>
+  )}
+
+  <ul class="space-y-8">
+    {filteredPosts.map(post => (
+      <li class="border-b border-gray-200 pb-6 mb-6">
+        <a href={`/blog/${post.slug}`} class="text-3xl font-playfair text-[color:var(--primary)] hover:underline">{post.title}</a>
+        <p class="text-sm text-gray-500 mt-1">{new Date(post.date).toLocaleDateString()}</p>
+        
+        {post.category && (
+          <p class="text-sm text-gray-600 mt-2">
+            <strong>Category:</strong> 
+            <a href={`/blog?category=${encodeURIComponent(post.category)}`} class="text-[color:var(--primary)] hover:underline ml-1">{post.category}</a>
+          </p>
+        )}
+        
+        {post.tags && post.tags.length > 0 && (
+          <div class="mt-2">
+            <strong>Tags:</strong> 
+            {post.tags.map(tag => (
+              <a href={`/blog?tag=${encodeURIComponent(tag)}`} class="inline-block bg-gray-100 text-gray-600 text-xs px-2 py-0.5 rounded-full mr-1 hover:bg-gray-200">{tag}</a>
+            ))}
+          </div>
+        )}
+        
+        <p class="mt-3 text-gray-700">{post.description}</p>
+        <a href={`/blog/${post.slug}`} class="inline-block mt-3 text-[color:var(--primary)] hover:underline">Read more &rarr;</a>
       </li>
     ))}
   </ul>
+  {filteredPosts.length === 0 && (
+    <p class="text-center text-gray-500 text-lg">No posts found matching your criteria.</p>
+  )}
 </section>


### PR DESCRIPTION
This commit introduces categorization and tagging functionality for blog posts.

Key changes:
- Updated the blog content schema (`src/content/config.ts`) to include optional `category` (string) and `tags` (array of strings) fields.
- Added sample blog posts with category and tag data in their frontmatter.
- Enhanced the blog index page (`src/pages/blog/index.astro`):
    - Displays category and tags for each post.
    - Lists all unique categories and tags as filter links.
    - Filters posts based on URL query parameters (`?category=` or `?tag=`).
- Updated the individual blog post page (`src/pages/blog/[slug].astro`):
    - Displays the category and tags for the current post.
    - Links the category and tags to the corresponding filtered views on the blog index page.

This feature improves blog navigation and content discovery for you.